### PR TITLE
bump version for release `v0.2.23`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "zombie-bite"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "array-bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zombie-bite"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2021"
 default-run = "zombie-bite"
 


### PR DESCRIPTION
Include bite at target block.