### PR TITLE
add support for westend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes 0.14.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -10812,6 +10812,8 @@ dependencies = [
 [[package]]
 name = "zombienet-configuration"
 version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c269216bae9a4628882f272d00d5e44be68091e7b468e75dc70fe7f3e838e4"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -10831,6 +10833,8 @@ dependencies = [
 [[package]]
 name = "zombienet-orchestrator"
 version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5fc4ca778d2bf804f6ea1983f248957452f55fbf06bbb47f31a2bfbbac516b"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -10867,6 +10871,8 @@ dependencies = [
 [[package]]
 name = "zombienet-prom-metrics-parser"
 version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa851f64b120ee4f5fc13f453f18bb3eb984225e21a91a480f713ecf23c409a0"
 dependencies = [
  "pest",
  "pest_derive",
@@ -10876,6 +10882,8 @@ dependencies = [
 [[package]]
 name = "zombienet-provider"
 version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a96858350524976ca391e88d637c51a1698de26a2a9de815b79ab99e53911f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10906,6 +10914,8 @@ dependencies = [
 [[package]]
 name = "zombienet-sdk"
 version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac89f216adc651f1bc3c064b53b2a907efee05acb1a6b272dce3d1419a9d9bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10930,6 +10940,8 @@ dependencies = [
 [[package]]
 name = "zombienet-support"
 version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e00dc9084a78b16d2c3d0bd1c79a34998466ce7f522187ec1c7880b250af4011"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,16 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
 ]
 
 [[package]]
@@ -449,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "ark-vrf"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9501da18569b2afe0eb934fb7afd5a247d238b94116155af4dd068f319adfe6d"
+checksum = "f69f34cb5a7d5d4627792c7a6343508becc19deab59a87ef73367cc112dfd02c"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-ec 0.5.0",
@@ -460,7 +469,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "digest 0.10.7",
- "rand_chacha 0.3.1",
+ "generic-array",
  "sha2 0.10.9",
  "w3f-ring-proof",
  "zeroize",
@@ -775,11 +784,11 @@ version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -822,9 +831,9 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "binary-merkle-tree"
-version = "16.1.0"
+version = "16.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c9f6900c9fd344d53fbdfb36e1343429079d73f4168c8ef48884bf15616dbd"
+checksum = "a6d867f1ffee8b07e7bee466f4f33a043b91f868f5c7b1d22d8a02f86e92bee8"
 dependencies = [
  "hash-db",
  "log",
@@ -833,11 +842,13 @@ dependencies = [
 
 [[package]]
 name = "bip39"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes 0.13.0",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -897,9 +908,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -940,30 +951,6 @@ checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
- "constant_time_eq 0.3.1",
-]
-
-[[package]]
-name = "blake2s_simd"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.6",
- "constant_time_eq 0.3.1",
-]
-
-[[package]]
-name = "blake3"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.6",
- "cc",
- "cfg-if",
  "constant_time_eq 0.3.1",
 ]
 
@@ -1055,9 +1042,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -1124,20 +1111,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
-name = "cid"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b68e3193982cd54187d71afdb2a271ad4cf8af157858e9cb911b91321de143"
-dependencies = [
- "core2",
- "multibase",
- "multihash 0.17.0",
- "serde",
- "unsigned-varint 0.7.2",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -1283,6 +1257,15 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
@@ -1345,36 +1328,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae7b60ec3fd7162427d3b3801520a1908bef7c035b52983cd3ca11b8e7deb51"
+checksum = "44f81cede359311706057b689b91b59f464926de0316f389898a2b028cb494fa"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6511c200fed36452697b4b6b161eae57d917a2044e6333b1c1389ed63ccadeee"
+checksum = "fa6ca11305de425ea08884097b913ebe1a83875253b3c0063ce28411e226bfdc"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7086a645aa58bae979312f64e3029ac760ac1b577f5cd2417844842a2ca07f"
+checksum = "7537341a9a4ba9812141927be733e7254bf2318aab6597d567af9cad90609f27"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5225b4dec45f3f3dbf383f12560fac5ce8d780f399893607e21406e12e77f491"
+checksum = "d28a4ca5faf25ff821fcc768f26e68ffef505e9f71bb06e608862d941fa65086"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1382,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858fb3331e53492a95979378d6df5208dd1d0d315f19c052be8115f4efc888e0"
+checksum = "d891057fe1b73910c41e73b32a70fa8454092fce65942b5fa6f72aa6d5487f8a"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1395,7 +1378,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.32.3",
  "hashbrown 0.15.3",
  "log",
  "pulley-interpreter",
@@ -1409,36 +1392,37 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456715b9d5f12398f156d5081096e7b5d039f01b9ecc49790a011c8e43e65b5f"
+checksum = "c29a66028a78eedc534b3a94e5ebfbaeb4e1f6b09038afe41bb24afd614faa4b"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
  "cranelift-srcgen",
+ "heck",
  "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0306041099499833f167a0ddb707e1e54100f1a84eab5631bc3dad249708f482"
+checksum = "95809ad251fe9422087b4a72d61e584d6ab6eff44dee1335f93cfaea0bedc9ac"
 
 [[package]]
 name = "cranelift-control"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1672945e1f9afc2297f49c92623f5eabc64398e2cb0d824f8f72a2db2df5af23"
+checksum = "f79d0cacf063c297e5e8d5b73cb355b41b87f6d248e252d1b284e7a7b73673c2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa3cd55eb5f3825b9ae5de1530887907360a6334caccdc124c52f6d75246c98a"
+checksum = "b2d73297a195ce3be55997c6307142c4b1e58dd0c2f18ceaa0179444024e312a"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1447,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781f9905f8139b8de22987b66b522b416fe63eb76d823f0b3a8c02c8fd9500c7"
+checksum = "3be38d1ae29ef7c5d611fc6cb694f698dc4ca44152dcaa112ec0fef8d4d34858"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1459,15 +1443,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05337a2b02c3df00b4dd9a263a027a07b3dff49f61f7da3b5d195c21eaa633d"
+checksum = "6761926f6636209de7ac568be28b206890f2181761375b9722e0a1e7a7e1637a"
 
 [[package]]
 name = "cranelift-native"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eee7a496dd66380082c9c5b6f2d5fa149cec0ec383feec5caf079ca2b3671c2"
+checksum = "0893472f73f0d530a28e9a573ada6d1f93b9659bb6734dfe17061ac967bd1830"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1476,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.122.0"
+version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b530783809a55cb68d070e0de60cfbb3db0dc94c8850dd5725411422bedcf6bb"
+checksum = "c1daccebabb1ccd034dbab0eacc0722af27d3cccc7929dea27a3546cb3562e40"
 
 [[package]]
 name = "crc32fast"
@@ -1725,6 +1709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,7 +1843,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -2109,6 +2102,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-display"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02058bb25d8d0605829af88230427dd5cd50661590bd2b09d1baf7c64c417f24"
+dependencies = [
+ "enum-display-macro",
+]
+
+[[package]]
+name = "enum-display-macro"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4be2cf2fe7b971b1865febbacd4d8df544aa6bd377cca011a6d69dcf4c60d94"
+dependencies = [
+ "convert_case 0.6.0",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2152,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2329,7 +2353,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c470df86cf28818dd3cd2fc4667b80dbefe2236c722c3dc1d09e7c6c82d6dfcd"
 dependencies = [
- "frame-metadata 23.0.0",
+ "frame-metadata 23.0.1",
  "parity-scale-codec",
  "scale-decode 0.16.0",
  "scale-encode 0.10.0",
@@ -2352,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c26fcb0454397c522c05fdad5380c4e622f8a875638af33bff5a320d1fc965"
+checksum = "9ba5be0edbdb824843a0f9c6f0906ecfc66c5316218d74457003218b24909ed0"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -2517,6 +2541,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxprof-processed-profile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+dependencies = [
+ "bitflags 2.11.1",
+ "debugid",
+ "fxhash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +2616,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
  "indexmap",
@@ -3455,6 +3498,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "jam-codec"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4222,7 +4285,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.8",
+ "yamux 0.13.10",
 ]
 
 [[package]]
@@ -4231,7 +4294,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "libc",
  "redox_syscall 0.5.12",
 ]
@@ -4319,19 +4382,21 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.10.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c666ef772d123a7643323ad4979c30dd825e9c68ec1aa5b387a6c9a9871c11ea"
+checksum = "cbf3924cf539a761465543592b34c4198d60db2cda16594769edd43451e5ab41"
 dependencies = [
  "async-trait",
  "bs58",
  "bytes",
- "cid 0.11.1",
+ "cid",
  "ed25519-dalek",
+ "enum-display",
  "futures",
  "futures-timer",
  "hickory-resolver 0.25.2",
  "indexmap",
+ "ip_network",
  "libc",
  "mockall",
  "multiaddr 0.17.1",
@@ -4340,8 +4405,9 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "prost 0.13.5",
- "prost-build",
+ "prost-build 0.14.3",
  "rand 0.8.5",
+ "ring 0.17.14",
  "serde",
  "sha2 0.10.9",
  "simple-dns",
@@ -4359,7 +4425,7 @@ dependencies = [
  "url",
  "x25519-dalek",
  "x509-parser 0.17.0",
- "yamux 0.13.8",
+ "yamux 0.13.10",
  "yasna",
  "zeroize",
 ]
@@ -4607,8 +4673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
  "blake2b_simd",
- "blake2s_simd",
- "blake3",
  "core2",
  "digest 0.10.7",
  "multihash-derive",
@@ -4771,7 +4835,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4884,10 +4948,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.3",
@@ -4941,7 +5036,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5202,6 +5297,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.3",
+ "indexmap",
+]
+
+[[package]]
+name = "picosimd"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8cf1ae70818c6476eb2da0ac8f3f55ecdea41a7aa16824ea6efc4a31cccf41"
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5262,22 +5374,23 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polkavm"
-version = "0.26.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa028f713d0613f0f08b8b3367402cb859218854f6b96fcbe39a501862894d6f"
+checksum = "d90ece49c68657299648e20469517e22c6ec38321307bb14a69c27a33927a491"
 dependencies = [
  "libc",
  "log",
+ "picosimd",
  "polkavm-assembler",
- "polkavm-common 0.26.0",
+ "polkavm-common 0.33.0",
  "polkavm-linux-raw",
 ]
 
 [[package]]
 name = "polkavm-assembler"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4859a29e1f4ad64610c4bc2bfc40bb9a535068a034933a5b56b5e7a0febf105a"
+checksum = "00010f7924647dbf6f468d85d0fcfe4c3587cfb4557ef13f3682dbece8fd57f0"
 dependencies = [
  "log",
 ]
@@ -5290,11 +5403,12 @@ checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
 
 [[package]]
 name = "polkavm-common"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a5794b695626ba70d29e66e3f4f4835767452a6723f3a0bc20884b07088fe8"
+checksum = "9e44a9487003cf5b9fc4462bbcf105cc37d5d9b18b40edf5ed50dd20ed1fdb27"
 dependencies = [
  "log",
+ "picosimd",
  "polkavm-assembler",
 ]
 
@@ -5309,11 +5423,11 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95282a203ae1f6828a04ff334145c3f6dc718bba6d3959805d273358b45eab93"
+checksum = "3ef966bc8518a66ce12d4edb73f2c4094cae72bb23258bc9e9b2802cc9d6cd79"
 dependencies = [
- "polkavm-derive-impl-macro 0.26.0",
+ "polkavm-derive-impl-macro 0.33.0",
 ]
 
 [[package]]
@@ -5330,11 +5444,11 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6069dc7995cde6e612b868a02ce48b54397c6d2582bd1b97b63aabbe962cd779"
+checksum = "f0c2166ad71dd7f51dcdd0d91b70d408a8b3610fa6e94d8202dd4b7185607181"
 dependencies = [
- "polkavm-common 0.26.0",
+ "polkavm-common 0.33.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5352,19 +5466,19 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581d34cafec741dc5ffafbb341933c205b6457f3d76257a9d99fb56687219c91"
+checksum = "c7ac2ac8ec5b938e249fa97b5ebb1e6fa47000c81a25eba6bf0f13edb8d430e4"
 dependencies = [
- "polkavm-derive-impl 0.26.0",
+ "polkavm-derive-impl 0.33.0",
  "syn 2.0.101",
 ]
 
 [[package]]
 name = "polkavm-linux-raw"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28919f542476f4158cc71e6c072b1051f38f4b514253594ac3ad80e3c0211fc8"
+checksum = "42063d4a1c52e569f7794df27dab3e19c9fa8946184023257bdbb43eb4a94be5"
 
 [[package]]
 name = "polling"
@@ -5643,6 +5757,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
 name = "prost-build"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5653,10 +5777,29 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost 0.13.5",
- "prost-types",
+ "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.101",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph 0.8.3",
+ "prettyplease",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "regex",
  "syn 2.0.101",
  "tempfile",
@@ -5689,6 +5832,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5698,10 +5854,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulley-interpreter"
-version = "35.0.0"
+name = "prost-types"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c4319786b16c1a6a38ee04788d32c669b61ba4b69da2162c868c18be99c1b"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost 0.14.3",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "36.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b78fdec962b639b921badfcfe77db7d18aa3c0c1e292ac2aa268c0efe8fe683"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -5711,9 +5876,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938543690519c20c3a480d20a8efcc8e69abeb44093ab1df4e7c1f81f26c677a"
+checksum = "f718f4e8cd5fdfa08b3b1d2d25fe288350051be330544305f0a9b93a937b3d42"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5795,7 +5960,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5925,7 +6090,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6166,7 +6331,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6179,7 +6344,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -6362,21 +6527,21 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "34.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01733879c581defda6f49ff4076033c675d7127bfab6fd0bd0e6cf10696d0564"
+checksum = "c0d3f1e8a1ed997d5fa6f86c005fb47c10b64184c68e611b1f310e3d039e44c7"
 dependencies = [
  "log",
- "sp-core 38.1.0",
- "sp-wasm-interface 24.0.0",
+ "sp-core 41.0.0",
+ "sp-wasm-interface 25.0.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "46.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962282c6d40861610814dac5159a99a5b4251d89269bb4e828ff766956f1833"
+checksum = "124e67d20414d12f73640ba2586a5d44d7646ec58ea41d2f1dfd5d98ff56b1aa"
 dependencies = [
  "array-bytes",
  "docify",
@@ -6390,7 +6555,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 38.1.0",
+ "sp-core 41.0.0",
  "sp-crypto-hashing",
  "sp-genesis-builder",
  "sp-io",
@@ -6413,9 +6578,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "42.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6de05f4f496f2261981b7d293ff4f5ba804bdfa924bf0cd1b48252a8a7051913"
+checksum = "f9736f1d5bf62be76f7a2f629be4443c4a14896f7eefc9987a68a0b4fd023538"
 dependencies = [
  "fnv",
  "futures",
@@ -6428,21 +6593,21 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 38.1.0",
+ "sp-core 41.0.0",
  "sp-database",
- "sp-externalities 0.30.0",
+ "sp-externalities 0.32.0",
  "sp-runtime",
  "sp-state-machine",
- "sp-storage 22.0.0",
+ "sp-storage 23.0.0",
  "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.45.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90511c3ab41be12af1ce88753de8993e0b8a5fc0453c0f48069ace06eb4a99d"
+checksum = "cef04379da853c1c14df0ebe8a394ddc6c042ff6e164d285db137edccf6eca14"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -6451,48 +6616,49 @@ dependencies = [
  "sc-executor-wasmtime",
  "schnellru",
  "sp-api",
- "sp-core 38.1.0",
- "sp-externalities 0.30.0",
+ "sp-core 41.0.0",
+ "sp-externalities 0.32.0",
  "sp-io",
  "sp-panic-handler",
- "sp-runtime-interface 32.0.0",
+ "sp-runtime-interface 35.0.0",
  "sp-trie",
  "sp-version",
- "sp-wasm-interface 24.0.0",
+ "sp-wasm-interface 25.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
-version = "0.41.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81bc77ad5df120ef1ffab877d71539aae878e916c0946a067e8d6b0508a7ea5"
+checksum = "f06c9a86b3475f8182b4e69b75c2b8563e6c71398ddce742f326ba1c2a136efd"
 dependencies = [
  "polkavm",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 24.0.0",
+ "sp-wasm-interface 25.0.0",
  "thiserror 1.0.69",
  "wasm-instrument",
 ]
 
 [[package]]
 name = "sc-executor-polkavm"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8976f310f09818f42ec389e727c91c0a75a8c363a29e3ac97d56492d83fc144f"
+checksum = "10bb402bec955b45c3a7882c8f3de3764dff9ce7705a4936ee7deb7c8ce01377"
 dependencies = [
  "log",
  "polkavm",
  "sc-executor-common",
- "sp-wasm-interface 24.0.0",
+ "sp-runtime-interface 35.0.0",
+ "sp-wasm-interface 25.0.0",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.41.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8f9b2a912f0cb435d2b8e33d67010e494b07f5c6e497d8756a8c21abad199e"
+checksum = "fe2b72c4c65ae32931f36979dd0ca27055f24a556f0308083b2101c1fddf09d1"
 dependencies = [
  "anyhow",
  "log",
@@ -6500,23 +6666,24 @@ dependencies = [
  "rustix 1.0.7",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 32.0.0",
- "sp-wasm-interface 24.0.0",
+ "sp-runtime-interface 35.0.0",
+ "sp-virtualization",
+ "sp-wasm-interface 25.0.0",
  "wasmtime",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.53.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc739c9acba911caecaae0a299650491fe6a837ab14d216a1f6c1987dfb6ef28"
+checksum = "fc0ac2bd45f377dec09ed4ff99aebaec8cad8c042dedd796766b0e4f1bf99ff9"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "asynchronous-codec 0.6.2",
  "bytes",
- "cid 0.9.0",
+ "cid",
  "either",
  "fnv",
  "futures",
@@ -6532,7 +6699,7 @@ dependencies = [
  "partial_sort",
  "pin-project",
  "prost 0.12.6",
- "prost-build",
+ "prost-build 0.13.5",
  "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
@@ -6544,7 +6711,7 @@ dependencies = [
  "smallvec",
  "sp-arithmetic",
  "sp-blockchain",
- "sp-core 38.1.0",
+ "sp-core 41.0.0",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -6558,9 +6725,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.51.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7419cbc4a107ec4f430b263408db1527f2ce5fd6ed136c279f22057d3d202965"
+checksum = "0143967106a7ad82e11667c4522519d78e204147369e7d0b9dc2d345ca52c855"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -6569,9 +6736,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.19.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79011e96426caf5240631af9c4d0f841a752ee2be606d782406745e76b1123dd"
+checksum = "7dad571c070fc5d7665b443a4b5f7c4644270159d92c19e9cc43ecb490c266fb"
 dependencies = [
  "bs58",
  "bytes",
@@ -6591,9 +6758,9 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661460d41cb14de3d8ad638bc34f9179eb2dd65791ccf71fa6dc0c572ad8100b"
+checksum = "7d8e894e2929df91a5b42cd98533673cd4846fd7a1ebd6fab2076a7bd24f6726"
 dependencies = [
  "chrono",
  "futures",
@@ -6611,9 +6778,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "42.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04c8e6a886fd4563be1cfe487af2f11280ea797298b8d831e1ee5a273cc17d"
+checksum = "1cd995c2b649e05d26f911326ab001ef62ed624caa213b5589a20f81f3ebf79c"
 dependencies = [
  "async-trait",
  "futures",
@@ -6622,16 +6789,17 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core 38.1.0",
+ "sp-core 41.0.0",
  "sp-runtime",
+ "strum",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-utils"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58dbfbc4408b0d210a6b7099c07caf02001e6975f62e316ea5b5c1f5c2108f4"
+checksum = "00454290e81f64bad3377a099543449bc4c6c909e1ade78ca307e20007c9b12c"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -6981,7 +7149,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -6994,7 +7162,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -7240,11 +7408,11 @@ dependencies = [
 
 [[package]]
 name = "simple-dns"
-version = "0.9.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
+checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -7428,9 +7596,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "39.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc9635cc2a860eff0b2d8b05ba217085c8292f41793f9cadfd931dc54976c00"
+checksum = "8977f83b4672cff5fff35a89a042e925d02f2a7dbfd63b7f4d12c80a2581f16b"
 dependencies = [
  "docify",
  "hash-db",
@@ -7438,11 +7606,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api-proc-macro",
- "sp-core 38.1.0",
- "sp-externalities 0.30.0",
+ "sp-core 41.0.0",
+ "sp-externalities 0.32.0",
  "sp-metadata-ir",
  "sp-runtime",
- "sp-runtime-interface 32.0.0",
+ "sp-runtime-interface 35.0.0",
  "sp-state-machine",
  "sp-trie",
  "sp-version",
@@ -7451,9 +7619,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "25.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d832cd107113d389340dc80a632330fe7ed7d20f3db50aeeb6abe40e23b6f4e"
+checksum = "32c95e3a2cadf60408a228d175d10bbacacdd2b1cd4a15115bc97e8d667ab0eb"
 dependencies = [
  "Inflector",
  "blake2",
@@ -7466,22 +7634,22 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "43.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6067f30cf3fb9270471cf24a65d73b33330f32573abab2d97196f83fc076de0"
+checksum = "fb47c341b52ca668e68929c982c9f4698b467012e1760b71f5be6cf8cf0fb49a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 38.1.0",
+ "sp-core 41.0.0",
  "sp-io",
 ]
 
 [[package]]
 name = "sp-arithmetic"
-version = "28.0.0"
+version = "28.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f4755af7cc57f4a2a830e134b403fc832caa5d93dacb970ffc7ac717f38c40"
+checksum = "4e06588d1c43f60b9bb7f989785689842cc4cc8ce0e19d1c47686b1ff5fe9548"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -7494,9 +7662,9 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "42.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082c634447671551ea1cb8f1182d1b8a7109f7316a044b974ad9e663935f56c8"
+checksum = "282bf400700c98decd130b61afd95a15c6d3064ad0366871bb400720ae203455"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7504,7 +7672,7 @@ dependencies = [
  "schnellru",
  "sp-api",
  "sp-consensus",
- "sp-core 38.1.0",
+ "sp-core 41.0.0",
  "sp-database",
  "sp-runtime",
  "sp-state-machine",
@@ -7514,16 +7682,19 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cdbfa4f10a4c0aac84f9fa3327386988aea983c503b9ec7f0bd8aa8c34c3f01"
+checksum = "e0151233b7598dbacd8a29982444e26240ea32cdf28370a844f3fa25d727187a"
 dependencies = [
  "async-trait",
  "futures",
  "log",
+ "sp-api",
+ "sp-externalities 0.32.0",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
+ "sp-trie",
  "thiserror 1.0.69",
 ]
 
@@ -7561,7 +7732,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sp-crypto-hashing",
- "sp-debug-derive",
+ "sp-debug-derive 14.0.0",
  "sp-externalities 0.29.0",
  "sp-runtime-interface 28.0.0",
  "sp-std",
@@ -7576,12 +7747,13 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "38.1.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707602208776d0e19d4269bb3f68c5306cacbdfabbb2e4d8d499af7b907bb0a3"
+checksum = "571e6da2db8de83fa2a6f9fab2a86befdcd004c90cfa19c641b072d3f322a60d"
 dependencies = [
  "ark-vrf",
  "array-bytes",
+ "bip39",
  "bitflags 1.3.2",
  "blake2",
  "bounded-collections 0.3.2",
@@ -7597,7 +7769,6 @@ dependencies = [
  "libsecp256k1",
  "log",
  "merlin",
- "parity-bip39",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "paste",
@@ -7610,10 +7781,10 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sp-crypto-hashing",
- "sp-debug-derive",
- "sp-externalities 0.30.0",
+ "sp-debug-derive 15.0.0",
+ "sp-externalities 0.32.0",
  "sp-std",
- "sp-storage 22.0.0",
+ "sp-storage 23.0.0",
  "ss58-registry",
  "substrate-bip39",
  "thiserror 1.0.69",
@@ -7649,9 +7820,9 @@ dependencies = [
 
 [[package]]
 name = "sp-database"
-version = "10.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722cbecdbf5b94578137dbd07feb51e95f7de221be0c1ff4dcfe0bb4cd986929"
+checksum = "c702cc7679fbaf0469d40251917cd27bfc165c506a8cd96fb4a9dd3947f06d70"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -7663,6 +7834,18 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "sp-debug-derive"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61809bf52be994e4d0a0485bb18a78509ed185e1418736c1ff9011bd1528999"
+dependencies = [
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7681,20 +7864,20 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cbf059dce180a8bf8b6c8b08b6290fa3d1c7f069a60f1df038ab5dd5fc0ba6"
+checksum = "ccab635fdf03594e8bec6213457df38389ad54ac15ce12fea22e9a88ba039c2f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-storage 22.0.0",
+ "sp-storage 23.0.0",
 ]
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f929edd118b6332b016e0e5a3eb962b8568b14eee024f818685f8ea5f80d53"
+checksum = "2cee8b7ba45f4b2d8a5720248e024489daf58a9b795ac3e24ac9a697938b0254"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7705,9 +7888,9 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "39.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2522693c705c1245ef8dbdbcf09d7cc6b139f0184d5e0a46856c546666b494d7"
+checksum = "4a298a87658bf4420b179fb15ee45ed885d77b53dc9627b1e858c16e1705417f"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -7719,9 +7902,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "43.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2059e3b338c0174e8dc9e144cc7e612165ca4c960c3a23c6c99c29ef34768f"
+checksum = "cc8f8415b05edacb24866790c540e29ff967250faffda9996709c2d48f0f6ca4"
 dependencies = [
  "bytes",
  "docify",
@@ -7729,14 +7912,14 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "polkavm-derive 0.26.0",
+ "polkavm-derive 0.33.0",
  "rustversion",
  "secp256k1 0.28.2",
- "sp-core 38.1.0",
+ "sp-core 41.0.0",
  "sp-crypto-hashing",
- "sp-externalities 0.30.0",
+ "sp-externalities 0.32.0",
  "sp-keystore",
- "sp-runtime-interface 32.0.0",
+ "sp-runtime-interface 35.0.0",
  "sp-state-machine",
  "sp-tracing 19.0.0",
  "sp-trie",
@@ -7746,21 +7929,21 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.44.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5c0b829014afc22e992be2c198f2677592db43267fc218e9f3207dbbfb6fbb"
+checksum = "74fead48d67f4374903b78624bca25fbf15f95a79d8dbefdecd407bb01544c3d"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core 38.1.0",
- "sp-externalities 0.30.0",
+ "sp-core 41.0.0",
+ "sp-externalities 0.32.0",
 ]
 
 [[package]]
 name = "sp-maybe-compressed-blob"
-version = "11.0.1"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d204064a17660455603ae152b02fc7ea4cfff2d14796f6483d7a35c4cca336"
+checksum = "d96bd622e9c93d874f70f8df15ba1512fb95d8339aa5629157a826ec65a0c568"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -7768,11 +7951,12 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1464c9e76f97c80a8dbccfe3f9fd4be0f25d0cc372efcf8fdf8791619b0998b9"
+checksum = "fb285f8d35b3fbb553e31c66182c25985717526f21920a08d23fdca88e3bdd1e"
 dependencies = [
- "frame-metadata 23.0.0",
+ "derive-where",
+ "frame-metadata 23.0.1",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -7789,11 +7973,12 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "44.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee57bb77e94c26306501426ac82aca401bb80ee2279ecdba148f68e76cf58247"
+checksum = "00f3c9491215e9d640c05ea651723f6834699f1088aa53043dc9badeb6177935"
 dependencies = [
  "binary-merkle-tree",
+ "bytes",
  "docify",
  "either",
  "hash256-std-hasher",
@@ -7808,11 +7993,12 @@ dependencies = [
  "simple-mermaid",
  "sp-application-crypto",
  "sp-arithmetic",
- "sp-core 38.1.0",
+ "sp-core 41.0.0",
  "sp-io",
  "sp-std",
  "sp-trie",
  "sp-weights",
+ "strum",
  "tracing",
  "tuplex",
 ]
@@ -7839,20 +8025,20 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "32.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdc2bc2adbfb9b4396ae07c7d94db20414d2351608e29e1f44e4f643b387c70"
+checksum = "1263162adb7ffe06c762467495dca536794667abe24567c7a00d5edd2b3e727c"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.26.0",
- "sp-externalities 0.30.0",
- "sp-runtime-interface-proc-macro 20.0.0",
+ "polkavm-derive 0.33.0",
+ "sp-externalities 0.32.0",
+ "sp-runtime-interface-proc-macro 21.0.0",
  "sp-std",
- "sp-storage 22.0.0",
+ "sp-storage 23.0.0",
  "sp-tracing 19.0.0",
- "sp-wasm-interface 24.0.0",
+ "sp-wasm-interface 25.0.0",
  "static_assertions",
 ]
 
@@ -7872,9 +8058,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04178084ae654b3924934a56943ee73e3562db4d277e948393561b08c3b5b5fe"
+checksum = "c7d9650b5186fd32bf5198adfe08d8fecc76f2ebe8a8927f28aaf2a537d75b2e"
 dependencies = [
  "Inflector",
  "expander",
@@ -7886,9 +8072,9 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.48.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042677239cca40eb6a0d70e0b220f5693516f59853c2d678de471a79652cd16e"
+checksum = "3789d2895faa6e5d0a88c34c19b8ca7f3fdd9823729bde83743fd13668aaf08a"
 dependencies = [
  "hash-db",
  "log",
@@ -7896,8 +8082,8 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "smallvec",
- "sp-core 38.1.0",
- "sp-externalities 0.30.0",
+ "sp-core 41.0.0",
+ "sp-externalities 0.32.0",
  "sp-panic-handler",
  "sp-trie",
  "thiserror 1.0.69",
@@ -7921,20 +8107,20 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive",
+ "sp-debug-derive 14.0.0",
 ]
 
 [[package]]
 name = "sp-storage"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3b70ca340e41cde9d2e069d354508a6e37a6573d66f7cc38f11549002f64ec"
+checksum = "e5e5c9fb0016b49765f89d23e4869ee616e1317de8f75b59babb721ccc27d2af"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive",
+ "sp-debug-derive 15.0.0",
 ]
 
 [[package]]
@@ -7964,9 +8150,9 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "41.1.0"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2a05942903900c23aaa5fded094fa8186523e646ae8874bff3fce74985d0e5"
+checksum = "1f4d4aa0fec3c80f98762cae84ad7dda64c16dcd37f1b97c34c9d3402023119f"
 dependencies = [
  "ahash",
  "foldhash",
@@ -7979,8 +8165,8 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 38.1.0",
- "sp-externalities 0.30.0",
+ "sp-core 41.0.0",
+ "sp-externalities 0.32.0",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tracing",
@@ -7990,15 +8176,16 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "42.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633ea19da3ec057d449af667099072daa4e99900984f304b96f4c2ee15aeecc7"
+checksum = "45a409b2e4cf147fc24ef158b3c6659738e7dca70838350309a3dc0cd59a81bc"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
+ "sp-core 41.0.0",
  "sp-crypto-hashing-proc-macro",
  "sp-runtime",
  "sp-std",
@@ -8020,6 +8207,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-virtualization"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd5b06a4cc35605887e9681cda701554d159e1cb757ec97b12a4c496fc96ed2"
+dependencies = [
+ "log",
+ "num_enum",
+ "parity-scale-codec",
+ "polkavm",
+ "sp-runtime-interface 35.0.0",
+ "sp-std",
+ "sp-wasm-interface 25.0.0",
+ "strum",
+]
+
+[[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8033,9 +8236,9 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd177d0658f3df0492f28bd39d665133a7868db5aa66c8642c949b6265430719"
+checksum = "7d29d5c802dbb12ce5efe240f1284842d285249b87530bb7729ddae2647c6b18"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -8046,9 +8249,9 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "33.1.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb3f1b1373a0926b44ddabfa55a608ea78c20ee356f35575c031db2f0202545"
+checksum = "364f93051b3b243c6221e51965e2bef465605f1de169a2ebd126fba2576dc3d9"
 dependencies = [
  "bounded-collections 0.3.2",
  "parity-scale-codec",
@@ -8056,7 +8259,7 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-arithmetic",
- "sp-debug-derive",
+ "sp-debug-derive 15.0.0",
 ]
 
 [[package]]
@@ -8115,6 +8318,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "subhasher"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8152,9 +8377,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
+checksum = "d93affb0135879b1b67cbcf6370a256e1772f9eaaece3899ec20966d67ad0492"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -8193,7 +8418,7 @@ dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata 23.0.0",
+ "frame-metadata 23.0.1",
  "futures",
  "hex",
  "jsonrpsee",
@@ -8248,7 +8473,7 @@ dependencies = [
  "blake2",
  "derive-where",
  "frame-decode",
- "frame-metadata 23.0.0",
+ "frame-metadata 23.0.1",
  "hashbrown 0.14.5",
  "hex",
  "impl-serde 0.5.0",
@@ -8309,7 +8534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fb7c0bfafad78dda7084c6a2444444744af3bbf7b2502399198b9b4c20eddf"
 dependencies = [
  "frame-decode",
- "frame-metadata 23.0.0",
+ "frame-metadata 23.0.1",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
@@ -8324,7 +8549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab68a9c20ecedb0cb7d62d64f884e6add91bb70485783bf40aa8eac5c389c6e0"
 dependencies = [
  "derive-where",
- "frame-metadata 23.0.0",
+ "frame-metadata 23.0.1",
  "futures",
  "hex",
  "impl-serde 0.5.0",
@@ -8440,7 +8665,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -8878,7 +9103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8969,9 +9194,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0670ab45a6b7002c7df369fee950a27cf29ae0474343fd3a15aa15f691e7a6"
+checksum = "a7795f2df2ef744e4ffb2125f09325e60a21d305cc3ecece0adeef03f7a9e560"
 dependencies = [
  "hash-db",
  "log",
@@ -9056,6 +9281,12 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -9263,9 +9494,9 @@ dependencies = [
 
 [[package]]
 name = "w3f-pcs"
-version = "0.0.2"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe7a8d5c914b69392ab3b267f679a2e546fe29afaddce47981772ac71bd02e1"
+checksum = "3ea1046a1deb6d26c34ba2d1f1bab4222d695d126502ee765f80b021753cb674"
 dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
@@ -9277,9 +9508,9 @@ dependencies = [
 
 [[package]]
 name = "w3f-plonk-common"
-version = "0.0.2"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aca389e494fe08c5c108b512e2328309036ee1c0bc7bdfdb743fef54d448c8c"
+checksum = "30408cda37b81bd7257319942584c794c5784d00d749757bc664656749a1472a"
 dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
@@ -9293,9 +9524,9 @@ dependencies = [
 
 [[package]]
 name = "w3f-ring-proof"
-version = "0.0.2"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a639379402ad51504575dbd258740383291ac8147d3b15859bdf1ea48c677de"
+checksum = "0cbfc4cb881a934e6f33c25927bf955d0cb18e52b94528bbc5fa28dddedb4cd1"
 dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
@@ -9414,12 +9645,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
+checksum = "724fccfd4f3c24b7e589d333fc0429c68042897a7e8a5f8694f31792471841e7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
@@ -9493,16 +9724,16 @@ version = "0.221.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.3",
  "indexmap",
  "semver",
@@ -9511,35 +9742,37 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aa8e9076de6b9544e6dab4badada518cca0bf4966d35b131bbd057aed8fa0a"
+checksum = "2df225df06a6df15b46e3f73ca066ff92c2e023670969f7d50ce7d5e695abbb1"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe976922a16af3b0d67172c473d1fd4f1aa5d0af9c8ba6538c741f3af686f4"
+checksum = "b10306ead921db2c4645ff99867b7539b65e18afd8816d471547f5e6f3b09492"
 dependencies = [
- "addr2line",
+ "addr2line 0.25.1",
  "anyhow",
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "bumpalo",
  "cc",
  "cfg-if",
- "gimli",
+ "fxprof-processed-profile",
+ "gimli 0.32.3",
  "hashbrown 0.15.3",
  "indexmap",
+ "ittapi",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.37.3",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -9547,37 +9780,39 @@ dependencies = [
  "rustix 1.0.7",
  "serde",
  "serde_derive",
+ "serde_json",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-cache",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-math",
  "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
  "wasmtime-internal-winch",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b6264a78d806924abbc76bbc75eac24976bc83bdfb938e5074ae551242436f"
+checksum = "e7fb2c37ca263d444f33871bf0221e7de0707b2b2bb88165df6db6d58c73375f"
 dependencies = [
  "anyhow",
  "cpp_demangle",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli",
+ "gimli 0.32.3",
  "indexmap",
  "log",
- "object",
+ "object 0.37.3",
  "postcard",
  "rustc-demangle",
  "serde",
@@ -9585,24 +9820,24 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "wasm-encoder",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmprinter",
 ]
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6775a9b516559716e5710e95a8014ca0adcc81e5bf4d3ad7899d89ae40094d1a"
+checksum = "19c6c0d3c8d2db554a3af8e8d413ff2815362ebce0911808ecfdaaa257438f93"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e33ad4bd120f3b1c77d6d0dcdce0de8239555495befcda89393a40ba5e324"
+checksum = "f1fe7d9a8dba289ddedc56da6cfb463127a5dc5f63f8199b63150cbcc35a3bc2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9614,15 +9849,15 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.9",
  "toml 0.8.22",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "zstd 0.13.3",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec9ad7565e6a8de7cb95484e230ff689db74a4a085219e0da0cbd637a29c01c"
+checksum = "5a2412f2afb0a5db2a4ac1cfff73247e240aeaa90bf41497ad0a5084b6a24eca"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9631,15 +9866,15 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli",
+ "gimli 0.32.3",
  "itertools 0.14.0",
  "log",
- "object",
+ "object 0.37.3",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.12",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-math",
  "wasmtime-internal-versioned-export-macros",
@@ -9647,9 +9882,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b636ff8b220ebaf29dfe3b23770e4b2bad317b9683e3bf7345e162387385b39"
+checksum = "ecfdc460dd5d343d88ff1ffaf65ae019feeb6124ddcfd3f39d28331068d25b1f"
 dependencies = [
  "anyhow",
  "cc",
@@ -9658,54 +9893,66 @@ dependencies = [
  "rustix 1.0.7",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "36.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5abb428a71827b7f90fc64406749883ccc6e58addf6d36974d5e06942011707"
+dependencies = [
+ "cc",
+ "object 0.37.3",
+ "rustix 1.0.7",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4417e06b7f80baff87d9770852c757a39b8d7f11d78b2620ca992b8725f16f50"
+checksum = "ba6cc13f14c3fb83fb877cb1d5c605e93f7ec1bf7fc1a5e8b361209d2f8ca028"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7710d5c4ecdaa772927fd11e5dc30a9a62d1fc8fe933e11ad5576ad596ab6612"
+checksum = "1cb209473a09f4dbd9c87bb9f18b8dcb0c9da30d12a260e3eacf7a1a53b41480"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ab22fabe1eed27ab01fd47cd89deacf43ad222ed7fd169ba6f4dd1fbddc53b"
+checksum = "aab4df5a04752106e1ecef9d40145ef28fa033b0d5dd3c839c9b208b2d522183"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307708f302f5dcf19c1bbbfb3d9f2cbc837dd18088a7988747b043a46ba38ecc"
+checksum = "5359875d29bddb6f7e65e698157714d8d35ebd8ea2a92893d05d6b062147b639"
 dependencies = [
  "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object",
+ "object 0.37.3",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342b0466f92b7217a4de9e114175fedee1907028567d2548bcd42f71a8b5b016"
+checksum = "2e247bcdd69701743ba386c933b26ebad2ce912ff9cb68b5b71fdb29d39ba04a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9714,16 +9961,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2012e7384c25b91aab2f1b6a1e1cbab9d0f199bbea06cc873597a3f047f05730"
+checksum = "d0298dfd9f57588222b5a92dcffe75894f1ead4e519850f176bde7fcfd105d54"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "gimli",
- "object",
+ "gimli 0.32.3",
+ "object 0.37.3",
  "target-lexicon",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -9812,19 +10059,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "35.0.0"
+version = "36.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839a334ef7c62d8368dbd427e767a6fbb1ba08cc12ecce19cbb666c10613b585"
+checksum = "2e2d7ea2137be52644d9c42ca5a4899bba07c2ed2db1e66c4c1994adfe35d39e"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli",
+ "gimli 0.32.3",
  "regalloc2",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.12",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-math",
@@ -9858,7 +10105,7 @@ checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-result 0.3.2",
  "windows-strings 0.4.0",
 ]
@@ -9892,6 +10139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9899,7 +10152,7 @@ checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result 0.3.2",
  "windows-strings 0.3.1",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -9917,7 +10170,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -9926,7 +10179,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -9935,7 +10188,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -9972,6 +10225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -10022,10 +10284,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -10241,7 +10504,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -10353,9 +10616,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.8"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deab71f2e20691b4728b349c6cee8fc7223880fa67b6b4f92225ec32225447e5"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
 dependencies = [
  "futures",
  "log",
@@ -10548,9 +10811,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-configuration"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e333d01dafa832ddd19360d701b9cfe95adbeac6a24af313a5d60f14d423f1"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -10569,12 +10830,12 @@ dependencies = [
 
 [[package]]
 name = "zombienet-orchestrator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35428664c52dfde114f2b6027e2e34aca331ce8e7891c5759bc2eb76d40a45a3"
+version = "0.4.13"
 dependencies = [
  "anyhow",
+ "array-bytes",
  "async-trait",
+ "erased-serde",
  "fancy-regex",
  "futures",
  "glob-match",
@@ -10582,6 +10843,7 @@ dependencies = [
  "libp2p",
  "libsecp256k1",
  "multiaddr 0.18.2",
+ "parity-scale-codec",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -10589,7 +10851,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "sp-core 38.1.0",
+ "sp-core 41.0.0",
  "subxt",
  "subxt-signer",
  "thiserror 1.0.69",
@@ -10604,9 +10866,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-prom-metrics-parser"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce10056be4114de0462d5281dfb1dcd21b9fbd3b0fae515e1d2a23471a44511"
+version = "0.4.13"
 dependencies = [
  "pest",
  "pest_derive",
@@ -10615,12 +10875,11 @@ dependencies = [
 
 [[package]]
 name = "zombienet-provider"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72a6f032e412fc26601888ab22f8aa6262d0da3a734c8918e90a03ab4d3a253"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "async-trait",
+ "erased-serde",
  "flate2",
  "futures",
  "hex",
@@ -10646,15 +10905,21 @@ dependencies = [
 
 [[package]]
 name = "zombienet-sdk"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb3db03375b0c1d0f251bb4913d4a1c8e2ca77d1eaa8e6d09d26a9ced5e0c40"
+version = "0.4.13"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "chrono",
+ "flate2",
  "futures",
+ "hex",
  "lazy_static",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
  "subxt",
  "subxt-signer",
+ "tar",
  "tokio",
  "zombienet-configuration",
  "zombienet-orchestrator",
@@ -10664,9 +10929,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-support"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2815367986941adc4c0d9d59f58e9e7c689c84909d7bd2eb99f36776cb4ce"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10677,6 +10940,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde_json",
+ "sp-core 41.0.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ default-run = "zombie-bite"
 
 
 [dependencies]
-zombienet-sdk = "0.4.12"
-zombienet-provider = "0.4.12"
-zombienet-orchestrator = "0.4.12"
-zombienet-support = "0.4.12"
-zombienet-configuration = "0.4.12"
+zombienet-sdk = "0.4.13"
+zombienet-provider = "0.4.13"
+zombienet-orchestrator = "0.4.13"
+zombienet-support = "0.4.13"
+zombienet-configuration = "0.4.13"
 clap = { version = "4.4.18", features = ["derive"] }
 tokio = "1"
 reqwest = { version = "0.12", features = ["json"] }
@@ -32,21 +32,12 @@ flate2 = "1.0"
 sp-core = "34.0.0"
 toml = "0.9"
 
-# [[bin]]
-# name = "doppelganger"
-# path = "src/doppelganger_cli.rs"
 
-# [[bin]]
-# name = "regular"
-# path = "src/regular.rs"
 
-# [[bin]]
-# name = "spawn"
-# path = "src/from_toml.rs"
-
-[patch.crates-io]
-zombienet-orchestrator =  { path = "../zombienet-sdk/crates/orchestrator" }
-zombienet-provider =  { path = "../zombienet-sdk/crates/provider" }
-zombienet-configuration = { path = "../zombienet-sdk/crates/configuration" }
-zombienet-support = { path = "../zombienet-sdk/crates/support" }
-zombienet-sdk = { path = "../zombienet-sdk/crates/sdk" }
+# local patch
+#[patch.crates-io]
+#zombienet-orchestrator =  { path = "../zombienet-sdk/crates/orchestrator" }
+#zombienet-provider =  { path = "../zombienet-sdk/crates/provider" }
+#zombienet-configuration = { path = "../zombienet-sdk/crates/configuration" }
+#zombienet-support = { path = "../zombienet-sdk/crates/support" }
+#zombienet-sdk = { path = "../zombienet-sdk/crates/sdk" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ default-run = "zombie-bite"
 
 
 [dependencies]
-zombienet-sdk = "0.4.2"
-zombienet-provider = "0.4.2"
-zombienet-orchestrator = "0.4.2"
-zombienet-support = "0.4.2"
-zombienet-configuration = "0.4.2"
+zombienet-sdk = "0.4.12"
+zombienet-provider = "0.4.12"
+zombienet-orchestrator = "0.4.12"
+zombienet-support = "0.4.12"
+zombienet-configuration = "0.4.12"
 clap = { version = "4.4.18", features = ["derive"] }
 tokio = "1"
 reqwest = { version = "0.12", features = ["json"] }
@@ -44,9 +44,9 @@ toml = "0.9"
 # name = "spawn"
 # path = "src/from_toml.rs"
 
-# [patch.crates-io]
-# zombienet-orchestrator =  { path = "../zombienet-sdk/crates/orchestrator" }
-# zombienet-provider =  { path = "../zombienet-sdk/crates/provider" }
-# zombienet-configuration = { path = "../zombienet-sdk/crates/configuration" }
-# zombienet-support = { path = "../zombienet-sdk/crates/support" }
-# zombienet-sdk = { path = "../zombienet-sdk/crates/sdk" }
+[patch.crates-io]
+zombienet-orchestrator =  { path = "../zombienet-sdk/crates/orchestrator" }
+zombienet-provider =  { path = "../zombienet-sdk/crates/provider" }
+zombienet-configuration = { path = "../zombienet-sdk/crates/configuration" }
+zombienet-support = { path = "../zombienet-sdk/crates/support" }
+zombienet-sdk = { path = "../zombienet-sdk/crates/sdk" }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ pub enum Commands {
         /// The network will be using for bite
         /// If not specified, will use the value from config.
         /// If not in config, defaults to polkadot.
-        #[arg(short = 'r', long = "rc", value_parser = clap::builder::PossibleValuesParser::new(["polkadot", "kusama", "paseo"]))]
+        #[arg(short = 'r', long = "rc", value_parser = clap::builder::PossibleValuesParser::new(["polkadot", "kusama", "paseo", "westend"]))]
         relay: Option<String>,
         /// If provided we will override the runtime as part of the process of 'bite'
         /// The resulting network will be running with this runtime.

--- a/src/config.rs
+++ b/src/config.rs
@@ -679,14 +679,14 @@ impl ParachainConfig {
 
                     let id: u32 = id
                         .parse()
-                        .expect(&format!("Invalid custom para id: {}", id));
+                        .unwrap_or_else(|_| panic!("Invalid custom para id: {}", id));
 
                     Some(Parachain::Custom {
                         maybe_override: self.runtime_override.clone(),
                         maybe_bite_at: self.bite_at,
                         maybe_rpc_endpoint: self.rpc_endpoint.clone(),
-                        chain_spec: chain_spec,
-                        id: id,
+                        chain_spec,
+                        id,
                         cores: self.cores.unwrap_or(1),
                     })
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@
 // TODO: don't allow dead_code
 
 use serde::{Deserialize, Serialize};
+// use zombienet_orchestrator::generators::chain_spec;
 use std::env;
 
 use zombienet_configuration::{NetworkConfig, NetworkConfigBuilder};
@@ -12,7 +13,7 @@ const AFTER: &str = "after";
 const DEBUG: &str = "debug";
 
 // `--state-pruning` config flag (two days +1 by default)
-pub const STATE_PRUNING: &str = "28801";
+pub const STATE_PRUNING: &str = "256";
 pub fn get_state_pruning_config() -> String {
     env::var("ZOMBIE_BITE_STATE_PRUNING").unwrap_or_else(|_| STATE_PRUNING.to_string())
 }
@@ -126,6 +127,48 @@ impl Context {
 type MaybeWasmOverridePath = Option<String>;
 type MaybeSyncUrl = Option<String>;
 type MaybeByteAt = Option<u32>;
+type MaybeChainSpec = Option<String>;
+
+// Get the current core assignment (data from May 2026)
+// polkadot
+// AH : 3
+// coretime: 1
+// people: 3
+// bridge: 1
+// collectives: 1
+
+// Westend
+// AH (1000): 3
+// coretime (1005): 1
+// people (1004): 3
+// bridge (1002): 1
+// collectives (1001): 1
+
+// Kusama
+// AH (1000): 3
+// coretim (1005): 1
+// people (1004): 1
+// bridge (1002): 1
+// collectives (1001): 1
+
+// Paseo
+// AH (1000): 3
+// coretime (1005): 1
+// people (1004): 1
+// bridge (1002): 1
+// collectives (1001): 1
+
+pub fn get_assigned_cores(relay: &Relaychain, para: &Parachain) -> u32 {
+    match para {
+        Parachain::AssetHub { .. } => 3,
+        Parachain::People { .. } => match relay {
+            Relaychain::Polkadot { .. } | Relaychain::Westend { .. } => 3,
+            _ => 1,
+        },
+        Parachain::Custom { cores, .. } => *cores,
+        _ => 1,
+    }
+}
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Relaychain {
@@ -145,6 +188,11 @@ pub enum Relaychain {
         maybe_sync_url: MaybeSyncUrl,
         maybe_bite_at: MaybeByteAt,
     },
+    Westend {
+        maybe_override: MaybeWasmOverridePath,
+        maybe_sync_url: MaybeSyncUrl,
+        maybe_bite_at: MaybeByteAt,
+    },
 }
 
 impl Relaychain {
@@ -156,6 +204,11 @@ impl Relaychain {
                 maybe_bite_at: None,
             },
             "paseo" => Self::Paseo {
+                maybe_override: None,
+                maybe_sync_url: None,
+                maybe_bite_at: None,
+            },
+            "westend" => Self::Westend {
                 maybe_override: None,
                 maybe_sync_url: None,
                 maybe_bite_at: None,
@@ -185,6 +238,11 @@ impl Relaychain {
                 maybe_sync_url,
                 maybe_bite_at,
             },
+            "westend" => Self::Westend {
+                maybe_override,
+                maybe_sync_url,
+                maybe_bite_at,
+            },
             _ => Self::Polkadot {
                 maybe_override,
                 maybe_sync_url,
@@ -198,6 +256,7 @@ impl Relaychain {
             Relaychain::Polkadot { .. } => "polkadot-local",
             Relaychain::Kusama { .. } => "kusama-local",
             Relaychain::Paseo { .. } => "paseo-local",
+            Relaychain::Westend { .. } => "westend-local",
         })
     }
 
@@ -206,6 +265,7 @@ impl Relaychain {
             Relaychain::Polkadot { .. } => "polkadot",
             Relaychain::Kusama { .. } => "kusama",
             Relaychain::Paseo { .. } => "paseo",
+            Relaychain::Westend { .. } => "westend",
         })
     }
 
@@ -215,6 +275,7 @@ impl Relaychain {
             Relaychain::Polkadot { .. } => "wss://rpc.polkadot.io",
             Relaychain::Kusama { .. } => "wss://kusama-rpc.polkadot.io",
             Relaychain::Paseo { .. } => "wss://paseo-rpc.dwellir.com",
+            Relaychain::Westend { .. } => "wss://westend-rpc.n.dwellir.com",
         })
     }
 
@@ -223,6 +284,7 @@ impl Relaychain {
             Relaychain::Polkadot { .. } => "wss://rpc.polkadot.io",
             Relaychain::Kusama { .. } => "wss://kusama-rpc.polkadot.io",
             Relaychain::Paseo { .. } => "wss://paseo-rpc.dwellir.com",
+            Relaychain::Westend { .. } => "wss://westend-rpc.n.dwellir.com",
         })
     }
 
@@ -234,6 +296,7 @@ impl Relaychain {
         match self {
             Relaychain::Kusama { maybe_override, .. }
             | Relaychain::Polkadot { maybe_override, .. }
+            | Relaychain::Westend { maybe_override, .. }
             | Relaychain::Paseo { maybe_override, .. } => maybe_override.as_deref(),
         }
     }
@@ -242,6 +305,7 @@ impl Relaychain {
         match self {
             Relaychain::Paseo { .. } => 600,
             Relaychain::Kusama { .. } => 600,
+            Relaychain::Westend { .. } => 600,
             _ => 2400,
         }
     }
@@ -250,6 +314,7 @@ impl Relaychain {
         match self {
             Relaychain::Kusama { maybe_bite_at, .. }
             | Relaychain::Polkadot { maybe_bite_at, .. }
+            | Relaychain::Westend { maybe_bite_at, .. }
             | Relaychain::Paseo { maybe_bite_at, .. } => *maybe_bite_at,
         }
     }
@@ -282,6 +347,14 @@ pub enum Parachain {
         maybe_bite_at: MaybeByteAt,
         maybe_rpc_endpoint: MaybeSyncUrl,
     },
+    Custom {
+        maybe_override: MaybeWasmOverridePath,
+        maybe_bite_at: MaybeByteAt,
+        maybe_rpc_endpoint: MaybeSyncUrl,
+        chain_spec: String,
+        id: u32,
+        cores: u32,
+    },
 }
 
 impl Parachain {
@@ -302,10 +375,19 @@ impl Parachain {
                 maybe_bite_at: None,
                 maybe_rpc_endpoint: None,
             },
-            _ => Parachain::AssetHub {
+            "asset-hub" => Parachain::AssetHub {
                 maybe_override: None,
                 maybe_bite_at: None,
                 maybe_rpc_endpoint: None,
+            },
+            // custom parachain
+            _ => Parachain::Custom {
+                maybe_override: None,
+                maybe_bite_at: None,
+                maybe_rpc_endpoint: None,
+                chain_spec: chain.to_string(),
+                id: 2000, // placeholder
+                cores: 1, // placeholder
             },
         }
     }
@@ -317,6 +399,7 @@ impl Parachain {
             Parachain::People { .. } => "people",
             Parachain::BridgeHub { .. } => "bridge-hub",
             Parachain::Collectives { .. } => "collectives",
+            Parachain::Custom { id, .. } => &id.to_string(),
         };
 
         format!("{para_part}-{relay_part}-local")
@@ -329,6 +412,7 @@ impl Parachain {
             Parachain::People { .. } => "people",
             Parachain::BridgeHub { .. } => "bridge-hub",
             Parachain::Collectives { .. } => "collectives",
+            Parachain::Custom { id, .. } => &id.to_string(),
         };
 
         format!("{para_part}-{relay_part}")
@@ -345,6 +429,7 @@ impl Parachain {
             Parachain::People { .. } => 1004,
             Parachain::BridgeHub { .. } => 1002,
             Parachain::Collectives { .. } => 1001,
+            Parachain::Custom { id, .. } => *id,
         }
     }
 
@@ -354,7 +439,8 @@ impl Parachain {
             | Parachain::Coretime { maybe_override, .. }
             | Parachain::People { maybe_override, .. }
             | Parachain::BridgeHub { maybe_override, .. }
-            | Parachain::Collectives { maybe_override, .. } => maybe_override.as_deref(),
+            | Parachain::Collectives { maybe_override, .. }
+            | Parachain::Custom { maybe_override, .. } => maybe_override.as_deref(),
         }
     }
 
@@ -364,7 +450,15 @@ impl Parachain {
             | Parachain::Coretime { maybe_bite_at, .. }
             | Parachain::People { maybe_bite_at, .. }
             | Parachain::BridgeHub { maybe_bite_at, .. }
-            | Parachain::Collectives { maybe_bite_at, .. } => *maybe_bite_at,
+            | Parachain::Collectives { maybe_bite_at, .. }
+            | Parachain::Custom { maybe_bite_at, .. } => *maybe_bite_at,
+        }
+    }
+
+    pub fn chain_spec(&self) -> Option<&str> {
+        match self {
+            Parachain::Custom { chain_spec, .. } => Some(chain_spec),
+            _ => None,
         }
     }
 
@@ -383,6 +477,9 @@ impl Parachain {
                 maybe_rpc_endpoint, ..
             }
             | Parachain::Collectives {
+                maybe_rpc_endpoint, ..
+            }
+            | Parachain::Custom {
                 maybe_rpc_endpoint, ..
             } => maybe_rpc_endpoint.as_deref(),
         }
@@ -416,7 +513,9 @@ pub fn generate_network_config(
     let para_context = Context::Parachain;
 
     let chain_spec_cmd = match network {
-        Relaychain::Polkadot { .. } | Relaychain::Kusama { .. } => CMD_TPL,
+        Relaychain::Polkadot { .. } | Relaychain::Kusama { .. } | Relaychain::Westend { .. } => {
+            CMD_TPL
+        }
         Relaychain::Paseo { .. } => DEFAULT_CHAIN_SPEC_TPL_COMMAND,
     };
 
@@ -467,8 +566,14 @@ pub fn generate_network_config(
             Parachain::People { .. } => ("people", para.id()),
             Parachain::BridgeHub { .. } => ("bridge-hub", para.id()),
             Parachain::Collectives { .. } => ("collectives", para.id()),
+            Parachain::Custom { chain_spec,.. } => (chain_spec.as_str(), para.id()),
         };
-        let chain = format!("{}-{}",chain_part, relay_chain);
+
+        let chain = if let Parachain::Custom { .. } = para {
+            chain_part.to_string()
+        } else {
+            format!("{}-{}",chain_part, relay_chain)
+        };
 
         let collator_name = format!("Collator-{}", id);
         builder.with_parachain(|p| {
@@ -528,6 +633,12 @@ pub struct ParachainConfig {
     pub enabled: Option<bool>, // default true
     pub bite_at: Option<u32>,
     pub rpc_endpoint: Option<String>,
+    // Parachain id. Used for custom
+    pub id: Option<String>,
+    // Parachain chain-spec (or full chain name). Used for custom.
+    pub chain_spec: Option<String>,
+    /// Number of cores to assign, NOTE: only used in `custom` paras
+    pub cores: Option<u32>,
 }
 
 impl ParachainConfig {
@@ -559,6 +670,26 @@ impl ParachainConfig {
                     maybe_bite_at: self.bite_at,
                     maybe_rpc_endpoint: self.rpc_endpoint.clone(),
                 }),
+                "custom" => {
+                    // validate chain / id
+                    let (Some(id), Some(chain_spec)) = (self.id.clone(), self.chain_spec.clone())
+                    else {
+                        panic!("Invalid custom parachain config, id and chain_spec are required");
+                    };
+
+                    let id: u32 = id
+                        .parse()
+                        .expect(&format!("Invalid custom para id: {}", id));
+
+                    Some(Parachain::Custom {
+                        maybe_override: self.runtime_override.clone(),
+                        maybe_bite_at: self.bite_at,
+                        maybe_rpc_endpoint: self.rpc_endpoint.clone(),
+                        chain_spec: chain_spec,
+                        id: id,
+                        cores: self.cores.unwrap_or(1),
+                    })
+                }
                 _ => None,
             }
         } else {
@@ -635,6 +766,9 @@ mod test {
             enabled: None, // Not specified
             bite_at: None,
             rpc_endpoint: None,
+            id: None,
+            chain_spec: None,
+            cores: None,
         };
 
         assert!(config.to_parachain().is_some());
@@ -652,6 +786,9 @@ mod test {
             enabled: Some(true),
             bite_at: None,
             rpc_endpoint: None,
+            id: None,
+            chain_spec: None,
+            cores: None,
         };
 
         assert!(config.to_parachain().is_some());
@@ -669,6 +806,9 @@ mod test {
             enabled: Some(false),
             bite_at: None,
             rpc_endpoint: None,
+            id: None,
+            chain_spec: None,
+            cores: None,
         };
 
         assert!(config.to_parachain().is_none());
@@ -683,6 +823,9 @@ mod test {
             enabled: Some(true),
             bite_at: None,
             rpc_endpoint: None,
+            id: None,
+            chain_spec: None,
+            cores: None,
         };
 
         let parachain = config.to_parachain().unwrap();
@@ -703,6 +846,9 @@ mod test {
             enabled: Some(true),
             bite_at: None,
             rpc_endpoint: None,
+            id: None,
+            chain_spec: None,
+            cores: None,
         };
 
         assert!(config.to_parachain().is_none());
@@ -719,6 +865,9 @@ mod test {
                 enabled: Some(true),
                 bite_at: None,
                 rpc_endpoint: None,
+                id: None,
+                chain_spec: None,
+                cores: None,
             };
 
             assert!(
@@ -973,6 +1122,9 @@ mod test {
                     enabled: Some(true),
                     bite_at: None,
                     rpc_endpoint: None,
+                    id: None,
+                    chain_spec: None,
+                    cores: None,
                 },
                 ParachainConfig {
                     parachain_type: "coretime".to_string(),
@@ -980,6 +1132,9 @@ mod test {
                     enabled: Some(false), // Disabled
                     bite_at: None,
                     rpc_endpoint: None,
+                    id: None,
+                    chain_spec: None,
+                    cores: None,
                 },
                 ParachainConfig {
                     parachain_type: "people".to_string(),
@@ -987,6 +1142,9 @@ mod test {
                     enabled: None, // Defaults to true
                     bite_at: None,
                     rpc_endpoint: None,
+                    id: None,
+                    chain_spec: None,
+                    cores: None,
                 },
             ]),
             base_path: None,

--- a/src/doppelganger.rs
+++ b/src/doppelganger.rs
@@ -150,7 +150,7 @@ pub async fn doppelganger_inner(
 
         let sync_chain_name = para.as_chain_string(&relay_chain.as_chain_string());
 
-        let chain_spec_path = format!("{}/{}-spec.json", &base_dir_str, &sync_chain_name);
+        let chain_spec_path = format!("{}/{}-spec.json", base_dir_str, sync_chain_name);
         generate_chain_spec(
             ns.clone(),
             &chain_spec_path,
@@ -161,7 +161,7 @@ pub async fn doppelganger_inner(
         .unwrap();
 
         // generate the data.tgz to use as snapshot
-        let snap_path = format!("{}/{}-snap.tgz", &base_dir_str, &sync_chain_name);
+        let snap_path = format!("{}/{}-snap.tgz", base_dir_str, sync_chain_name);
         trace!("snap_path: {snap_path}");
         generate_snap(&sync_db_path, &snap_path).await.unwrap();
 
@@ -237,7 +237,7 @@ pub async fn doppelganger_inner(
     // get the chain-spec (prod) and clean the bootnodes
     // relaychain
     let context_relay = Context::Relaychain;
-    let r_chain_spec_path = format!("{}/{}-spec.json", &base_dir_str, &sync_chain);
+    let r_chain_spec_path = format!("{}/{}-spec.json", base_dir_str, sync_chain);
     generate_chain_spec(
         ns.clone(),
         &r_chain_spec_path,
@@ -268,7 +268,7 @@ pub async fn doppelganger_inner(
         .expect("remove parachains db should work");
 
     // generate the data.tgz to use as snapshot
-    let r_snap_path = format!("{}/{}-snap.tgz", &base_dir_str, &sync_chain);
+    let r_snap_path = format!("{}/{}-snap.tgz", base_dir_str, sync_chain);
     generate_snap(&sync_db_path, &r_snap_path).await.unwrap();
 
     let relay_artifacts = ChainArtifact {
@@ -866,8 +866,8 @@ async fn generate_chain_spec(
 }
 
 async fn run_doppelganger_node(ns: DynNamespace, base_path: &Path) -> Result<(), String> {
-    let data_path = format!("{}/sync_db", &base_path.to_string_lossy());
-    let logs_path = format!("{}/sync.log", &base_path.to_string_lossy());
+    let data_path = format!("{}/sync_db", base_path.to_string_lossy());
+    let logs_path = format!("{}/sync.log", base_path.to_string_lossy());
     info!(
         "⛓  Syncing using warp, this could take a while. You can follow the logs with: \n\t
     tail -f {}",
@@ -889,7 +889,7 @@ async fn run_doppelganger_node(ns: DynNamespace, base_path: &Path) -> Result<(),
                     "-c",
                     format!(
                         "doppelganger -l doppelganger=debug --chain kusama --sync warp -d {} > {} 2>&1",
-                        &data_path, &logs_path
+                        data_path, logs_path
                     )
                     .as_str(),
                 ])

--- a/src/doppelganger.rs
+++ b/src/doppelganger.rs
@@ -36,7 +36,9 @@ use crate::utils::{
     get_header_from_block, get_random_port, localize_config, para_head_key, HeadData,
 };
 
-use crate::config::{get_state_pruning_config, Context, Parachain, Relaychain, Step};
+use crate::config::{
+    get_assigned_cores, get_state_pruning_config, Context, Parachain, Relaychain, Step,
+};
 use crate::overrides::{generate_default_overrides_for_para, generate_default_overrides_for_rc};
 use crate::sync::{sync_para, sync_relay_only};
 
@@ -44,6 +46,7 @@ use std::env;
 
 const PORTS_FILE: &str = "ports.json";
 const READY_FILE: &str = "ready.json";
+const VALIDATOR_ENV: (&str, &str) = ("ZOMBIE_DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION", "1");
 
 #[derive(Debug, Clone)]
 struct ChainArtifact {
@@ -95,7 +98,7 @@ pub async fn doppelganger_inner(
         let maybe_target_header_path = if let Some(at_block) = para.at_block() {
             let para_rpc = para
                 .rpc_endpoint()
-                .expect("rpc for parachain should be set. qed");
+                .expect("'rpc_endpoint' for parachain should be set when use 'bite_at' to get the target header. qed");
             let header = get_header_from_block(at_block, para_rpc).await?;
 
             let target_header_path = format!("{base_dir_str}/para-header.json");
@@ -132,14 +135,20 @@ pub async fn doppelganger_inner(
     for (para_index, (_sync_node, sync_db_path, sync_chain, sync_head_path)) in
         res.into_iter().enumerate()
     {
-        let sync_chain_name = if sync_chain.contains('/') {
-            let parts: Vec<&str> = sync_chain.split('/').collect();
-            let name_parts: Vec<&str> = parts.last().unwrap().split('.').collect();
-            name_parts.first().unwrap().to_string()
-        } else {
-            // is not a file
-            sync_chain.clone()
-        };
+        let para = paras_to
+            .get(para_index)
+            .expect("para_index should be valid. qed");
+
+        // let sync_chain_name = if sync_chain.contains('/') {
+        //     let parts: Vec<&str> = sync_chain.split('/').collect();
+        //     let name_parts: Vec<&str> = parts.last().unwrap().split('.').collect();
+        //     name_parts.first().unwrap().to_string()
+        // } else {
+        //     // is not a file
+        //     sync_chain.clone()
+        // };
+
+        let sync_chain_name = para.as_chain_string(&relay_chain.as_chain_string());
 
         let chain_spec_path = format!("{}/{}-spec.json", &base_dir_str, &sync_chain_name);
         generate_chain_spec(
@@ -170,16 +179,13 @@ pub async fn doppelganger_inner(
                 .encode(),
         );
 
-        let para = paras_to
-            .get(para_index)
-            .expect("para_index should be valid. qed");
         para_heads_env.push((
             format!("ZOMBIE_{}", &para_head_key(para.id())[2..]),
             para_head[2..].to_string(),
         ));
 
         para_artifacts.push(ChainArtifact {
-            cmd: context_para.doppelganger_cmd(),
+            cmd: context_para.cmd(),
             chain: if sync_chain.contains('/') {
                 para.as_chain_string(&relay_chain.as_chain_string())
             } else {
@@ -192,8 +198,11 @@ pub async fn doppelganger_inner(
         });
     }
 
+    let req_cores: u32 = paras_to.iter().fold(0u32, |acc, para| {
+        acc + get_assigned_cores(&relay_chain, para)
+    });
     let rc_default_overrides_path =
-        generate_default_overrides_for_rc(&base_dir_str, &relay_chain, &paras_to).await;
+        generate_default_overrides_for_rc(&base_dir_str, &relay_chain, &paras_to, req_cores).await;
     let rc_info_path = format!("{base_dir_str}/rc_info.txt");
     // RELAYCHAIN sync
 
@@ -241,6 +250,8 @@ pub async fn doppelganger_inner(
     // remove `parachains` db
     let sync_chain_in_path = if sync_chain == "kusama" {
         "ksmcc3"
+    } else if sync_chain == "westend" {
+        "westend2"
     } else {
         sync_chain.as_str()
     };
@@ -261,7 +272,8 @@ pub async fn doppelganger_inner(
     generate_snap(&sync_db_path, &r_snap_path).await.unwrap();
 
     let relay_artifacts = ChainArtifact {
-        cmd: context_relay.doppelganger_cmd(),
+        // cmd: context_relay.doppelganger_cmd(),
+        cmd: context_relay.cmd(),
         chain: sync_chain,
         spec_path: r_chain_spec_path,
         snap_path: r_snap_path,
@@ -274,6 +286,7 @@ pub async fn doppelganger_inner(
         para_artifacts,
         Some(global_base_dir.clone()),
         database,
+        req_cores,
     )
     .await
     .map_err(|e| anyhow!(e.to_string()))?;
@@ -539,6 +552,7 @@ async fn generate_config(
     paras: Vec<ChainArtifact>,
     global_base_dir: Option<PathBuf>,
     database: &str,
+    req_cores: u32,
 ) -> Result<NetworkConfig, String> {
     let leaked_rust_log = env::var("RUST_LOG_RC").unwrap_or_else(|_| {
         String::from(
@@ -601,7 +615,8 @@ async fn generate_config(
     };
 
     // Alice + Bob + number of parachains
-    let num_validators = (2 + paras.len()).min(7);
+    // let num_validators = (2 + paras.len()).min(7);
+    let num_validators = (2 + req_cores).min(7) as usize;
 
     // config a new network with dynamic validators
     let mut config = NetworkConfigBuilder::new().with_relaychain(|r| {
@@ -629,8 +644,16 @@ async fn generate_config(
 
         {
             let mut relay_builder = relay_builder
-                .with_validator(|node| node.with_name("alice").with_rpc_port(rpc_alice_port))
-                .with_validator(|node| node.with_name("bob").with_rpc_port(rpc_bob_port));
+                .with_validator(|node| {
+                    node.with_name("alice")
+                        .with_rpc_port(rpc_alice_port)
+                        .with_env(vec![VALIDATOR_ENV])
+                })
+                .with_validator(|node| {
+                    node.with_name("bob")
+                        .with_rpc_port(rpc_bob_port)
+                        .with_env(vec![VALIDATOR_ENV])
+                });
 
             let additional_validators = ["charlie", "dave", "ferdie", "eve", "one"];
             // Spawn validators based on total count, accounting for alice and bob already added
@@ -638,25 +661,15 @@ async fn generate_config(
                 .iter()
                 .take(num_validators.saturating_sub(2))
             {
-                relay_builder = relay_builder.with_validator(|node| node.with_name(*name));
+                relay_builder = relay_builder
+                    .with_validator(|node| node.with_name(*name).with_env(vec![VALIDATOR_ENV]));
             }
             relay_builder
         }
     });
 
     if !paras.is_empty() {
-        // TODO: enable for multiple paras
-        // let validation_context = Rc::new(RefCell::new(ValidationContext::default()));
         for para in paras {
-            // TODO: enable for multiple paras
-            // let builder = ParachainConfigBuilder::new(validation_context);
-            // let para_config = builder.with_id(1000)
-            // .with_chain(para.chain.as_str())
-            // .with_default_command(para.cmd.as_str())
-            // .with_chain_spec_path(PathBuf::from(para.spec_path.as_str()))
-            // .with_default_db_snapshot(PathBuf::from(para.snap_path.as_str()))
-            // .with_collator(|c| c.with_name("col-1000"));
-
             let (chain_spec_path, db_path) = if let Ok(ci_path) = env::var("ZOMBIE_BITE_CI_PATH") {
                 let chain_spec_path = PathBuf::from(para.spec_path.as_str());
                 let chain_spec_filename = chain_spec_path
@@ -714,6 +727,10 @@ async fn generate_config(
                 for extra in extra_args.split(',') {
                     para_default_args.push(extra.trim().into());
                 }
+            }
+
+            if para.chain.contains("asset-hub") {
+                para_default_args.push("--authoring=slot-based".into());
             }
 
             let para_id = para.para_id.expect("Para id should be available");
@@ -981,7 +998,7 @@ mod test {
             para_id: Some(1000),
         };
 
-        let network_config = generate_config(relay, vec![ah], None, "rocksdb")
+        let network_config = generate_config(relay, vec![ah], None, "rocksdb", 3)
             .await
             .unwrap();
 

--- a/src/overrides.rs
+++ b/src/overrides.rs
@@ -169,8 +169,7 @@ fn augment_overrides_for_paras(relay: &Relaychain, paras: &[&Parachain], overrid
     let mut core_index = 0_u32;
     let mut para_scheduler_value_parts: Vec<String> = vec![];
 
-    for (_i, para) in paras.iter().enumerate() {
-        // let index: u32 = index.try_into().expect("Index should be valid u32");
+    for  para in paras.iter() {
         let para_id = ParaId(para.id());
 
         let para_twox64 = array_bytes::bytes2hex("", subhasher::twox64(para_id.encode()));
@@ -387,7 +386,7 @@ mod test {
             "",
             substorager::storage_value_key(&b"Babe"[..], b"GenesisSlot"),
         );
-        let mut a = 295769115_u64;
+        let a = 295769115_u64;
         let a_encoded = a.encode();
         println!("{}: {}", prefix, array_bytes::bytes2hex("", a_encoded));
     }
@@ -396,7 +395,7 @@ mod test {
     fn encode_u32() {
         let a = 100_u32;
         let a_encoded = a.encode();
-        println!("{}: {}", "a", array_bytes::bytes2hex("", a_encoded));
+        println!("encoded: {}", array_bytes::bytes2hex("", a_encoded));
     }
 
     #[test]

--- a/src/overrides.rs
+++ b/src/overrides.rs
@@ -4,12 +4,14 @@ use std::{env, path::PathBuf};
 use tokio::fs;
 
 use crate::{
-    config::{Parachain, Relaychain},
+    config::{get_assigned_cores, Parachain, Relaychain},
     utils::{
         generate_collator_key_from_seed, generate_collator_next_keys_injects, get_validator_keys,
         ParaId, ValidationCode,
     },
 };
+
+use zombienet_sdk::generators::core_assignment;
 
 /// Generate the injects for Session.NextKeys storage overrides for validators
 fn generate_next_keys_injects(
@@ -28,16 +30,27 @@ fn generate_next_keys_injects(
     next_keys_injects
 }
 
+// Build HostConfig per Relay
+fn host_config(relay: &Relaychain, num_cores: u32) -> String {
+    let cores = array_bytes::bytes2hex("", num_cores.encode());
+    match relay {
+        Relaychain::Westend { .. } => {
+            format!("00003000005000005555150000008000fbff0100000200000a000000c80000006400000006000000020000000000a00000c800000a00000000c0220fca950300000000000000000000c0220fca9503000000000000000000e8030000009001000a000000009001000c01002000000600c4090000000000000601983a0000000000008070000001c800000006000000580200000200000028000000000000000200000001000000020000000f00000002000000100a010000000a00000005000000010500000005000000{}1027000080b2e60e80c3c9018096980000000000000000000000000000000000", cores)
+        }
+        Relaychain::Polkadot { .. } => {
+            format!("0000300000500000aaaa020000001000fbff0000100000000a000000403800005802000003000000020000000000a00000c800008000000000e8764817000000000000000000000000e87648170000000000000000000000190000000090010080000000009001000c01002000000600c4090000000000000601983a0000000000004038000000060000005802000003000000d5000000000000001e00000006000000020000001400000002000000100b060000000a0000000a000000010500000005000000{}f401000080b2e60e80c3c90180b2e60e00000000000000000000000000000000", cores)
+        }
+        Relaychain::Kusama { .. } => {
+            format!("0000300000500000aaaa0a0000004000fbff0000800000000a000000100e00005802000006000000020000000000a00000c800001e000000005039278c0400000000000000000000005039278c040000000000000000000019000000009001001e000000009001000c01002000000600c4090000000000000601983a0000000000008070000001bc0200000600000058020000030000002b010000000000001e00000006000000020000001400000002000000100b060000000a0000000a000000010500000005000000{}f401000080b2e60e80c3c90100f2052a01000000000000000000000000000000", cores)
+        }
+        Relaychain::Paseo { .. } => {
+            format!("e067350000800000aaaa020000001000fbff0000100000000a0000003c0000003c00000003000000020000000000a00000c800001e0000000000000000000000000000000000000000000000000000000000000000000000e8030000009001001e000000009001000c01002000000600c4090000000000000601983a000000000000b00400000006000000640000000200000019000000000000000200000002000000020000000500000001000000100b010000000a00000004000000010300000005000000{}6400000080b2e60e80c3c9018096980000000000000000000000000000000000", cores)
+        }
+    }
+}
 /// Generate the storage overrides for relay chain validators
-pub fn generate_rc_overrides(
-    validator_keys: &[&crate::utils::ValidatorKeys],
-    paras: &[&Parachain],
-) -> serde_json::Value {
+pub fn generate_rc_overrides(validator_keys: &[&crate::utils::ValidatorKeys]) -> serde_json::Value {
     let num_validators = validator_keys.len();
-    let num_cores: u32 = paras
-        .len()
-        .try_into()
-        .expect("The number of paras needs to fit into a u32.");
 
     // Build stash list for validators (concatenated hex)
     let stash_list: String = validator_keys
@@ -96,12 +109,8 @@ pub fn generate_rc_overrides(
     // Format validator count as compact encoded
     let validator_count_hex = format!("{:02x}", num_validators * 4); // *4 because we encode each as 4 bytes
 
-    // Generate paras_parachains
-    let para_ids: Vec<u32> = paras.iter().map(|para| para.id()).collect();
-    let paras_parachains = generate_paras_parachains_value(para_ids);
-
     // Build base overrides object
-    let mut overrides = json!({
+    let overrides = json!({
         // Validator Validators (dynamic list)
         "7d9fe37370ac390779f35763d98106e888dcde934c658227ee1dfafcd6e16903": format!("{}{}", validator_count_hex, stash_list),
         // Session Validators (dynamic list)
@@ -116,8 +125,6 @@ pub fn generate_rc_overrides(
         "5f9cc45b7a00c5899361e1c6099678dc5e0621c4869aa60c02be9adcc98a0d1d": format!("{}{}", validator_count_hex, grandpa_authorities),
         // Staking Invulnerables (dynamic list)
         "5f3e4907f716ac89b6347d15ececedca5579297f4dfb9609e7e4c2ebab9ce40a": format!("{}{}", validator_count_hex, stash_list),
-        // paras parachains (dynamic based on first parachain)
-        "cd710b30bd2eab0352ddcc26417aa1940b76934f4cc08dee01012d059e1b83ee": paras_parachains,
         // paraScheduler validatorGroup (dynamic groups based on validator count)
         "94eadf0156a8ad5156507773d0471e4a16973e1142f5bd30d9464076794007db": format!("{}{}", validator_groups_count_hex, validator_groups),
         // paraScheduler claimQueue (empty, will auto-fill)
@@ -130,14 +137,23 @@ pub fn generate_rc_overrides(
         "2099d7f109d6e535fb000bba623fd4409f99a2ce711f3a31b2fc05604c93f179": format!("{}{}", validator_count_hex, authority_discovery_keys),
         // authorityDiscovery nextKeys (dynamic)
         "2099d7f109d6e535fb000bba623fd4404c014e6bf8b8c2c011e7290b85696bb3": format!("{}{}", validator_count_hex, authority_discovery_keys),
-        // Configuration activeConfig, {x} cores and node_features [1101]
-        "06de3d8a54d27e44a9d5ce189618f22db4b49d95320d9021994c850f25b8e385": format!("0000300000500000aaaa020000001000fbff0000100000000a000000403800005802000003000000020000000000500000c800008000000000e8764817000000000000000000000000e87648170000000000000000000000e80300000090010080000000009001000c01002000000600c4090000000000000601983a000000000000403800000006000000580200000300000019000000000000000200000002000000020000001400000001000000100b010000001400000004000000010500000001000000{}00000000f401000080b2e60e80c3c90180b2e60e00000000000000000000000005000000", array_bytes::bytes2hex("", num_cores.encode())),
-        // TODO: is this needed?
         // paraScheduler availabilityCores (1 core, free)
         "94eadf0156a8ad5156507773d0471e4ab8ebad86f546c7e0b135a4212aace339": "0400",
         // Sudo Key (Alice)
         "5c0d1176a568c1f92944340dbfed9e9c530ebca703c85910e7164cb7d1c9e47b": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
     });
+
+    overrides
+}
+
+fn augment_overrides_for_paras(relay: &Relaychain, paras: &[&Parachain], overrides: &mut Value) {
+    // Generate paras_parachains
+    let para_ids: Vec<u32> = paras.iter().map(|para| para.id()).collect();
+    let paras_parachains = generate_paras_parachains_value(para_ids);
+
+    // paras parachains (dynamic based on first parachain)
+    overrides["cd710b30bd2eab0352ddcc26417aa1940b76934f4cc08dee01012d059e1b83ee"] =
+        json!(paras_parachains);
 
     // Add DMP and HRMP storage keys for each parachain
     let dmp_dmqh_prefix = array_bytes::bytes2hex(
@@ -148,12 +164,13 @@ pub fn generate_rc_overrides(
         "",
         substorager::storage_value_key(&b"Hrmp"[..], b"HrmpIngressChannelsIndex"),
     );
-    let core_descriptor_prefix = array_bytes::bytes2hex(
-        "",
-        substorager::storage_value_key(&b"CoretimeAssignmentProvider"[..], b"CoreDescriptors"),
-    );
-    for (index, para) in paras.iter().enumerate() {
-        let index: u32 = index.try_into().expect("Index should be valid u32");
+
+    // used to assign cores
+    let mut core_index = 0_u32;
+    let mut para_scheduler_value_parts: Vec<String> = vec![];
+
+    for (_i, para) in paras.iter().enumerate() {
+        // let index: u32 = index.try_into().expect("Index should be valid u32");
         let para_id = ParaId(para.id());
 
         let para_twox64 = array_bytes::bytes2hex("", subhasher::twox64(para_id.encode()));
@@ -169,36 +186,50 @@ pub fn generate_rc_overrides(
         let hrmp_channels_key = format!("{hrmp_hici_prefix}{para_key_part}");
         overrides[hrmp_channels_key] = json!("00");
 
-        // CoretimeAssignmentProvider CoreDescriptors <idx>
-        let core_descriptor_idx_key = format!(
-            "{core_descriptor_prefix}{}",
-            array_bytes::bytes2hex("", subhasher::twox256(index.to_le_bytes()))
-        );
-        let core_descriptor = format!("00010402{}00e100e100010000e1", para_hex);
-        overrides[core_descriptor_idx_key] = json!(core_descriptor);
-    }
+        // ParaScheduler
+        let para_cores = get_assigned_cores(relay, para);
+        for _ in 0..para_cores {
+            para_scheduler_value_parts.push(core_assignment::generate(core_index, para.id()));
+            core_index += 1;
+        }
 
-    overrides
+        let count_prefix = format!("{:02x}", para_scheduler_value_parts.len() * 4);
+        let core_assign_value = format!("{count_prefix}{}", para_scheduler_value_parts.join(""));
+        // key is generated with prefix (`0x`)
+        let scheduler_key = core_assignment::get_parascheduler_storage_key();
+        overrides[&scheduler_key[2..]] = json!(core_assign_value);
+    }
 }
 
 pub async fn generate_default_overrides_for_rc(
     base_dir: &str,
     relay: &Relaychain,
     paras: &Vec<Parachain>,
+    req_cores: u32,
 ) -> PathBuf {
-    // Alice + Bob + number of parachains
-    let num_validators = (2 + paras.len()).min(7);
-    let validator_keys = get_validator_keys(num_validators);
+    // The number of required validators, is equal the number of requested cores by paras + 1
+    let num_validators = (1 + req_cores).min(7);
+    let validator_keys = get_validator_keys(num_validators as usize);
 
     let next_keys_injects = generate_next_keys_injects(&validator_keys);
 
     // Generate the rc overrides with parachains
     let paras_refs: Vec<&Parachain> = paras.iter().collect();
-    let mut overrides = generate_rc_overrides(&validator_keys, &paras_refs);
+    let mut overrides = generate_rc_overrides(&validator_keys);
+
+    // add the paras related keys to override to _overrides_ json
+    augment_overrides_for_paras(relay, &paras_refs, &mut overrides);
+
+    // Override Configuration activeConfig
+    overrides["06de3d8a54d27e44a9d5ce189618f22db4b49d95320d9021994c850f25b8e385"] =
+        json!(host_config(relay, req_cores));
 
     // Keys to inject (mostly storage maps that are not present in the current state)
     // <Pallet> < Item>
     let mut injects = next_keys_injects;
+
+    // set `UsePreviousValidators` to true to keep using the same validator set.
+    injects["c57d82d01f0fc18afc048ca20ac460dd"] = json!("01");
 
     // RcMigrator Manager (set //Alice by default)
     injects["2185d18cb42ae97242af0e70e6ad689012fcd13ee43ae32cc87f798eb5ed3295"] =
@@ -222,7 +253,8 @@ pub async fn generate_default_overrides_for_rc(
         overrides["3a636f6465"] = Value::String(hex::encode(wasm_content));
     }
 
-    // also check if any parachain includes a wasm override
+    // also check if any parachain includes a wasm override but we can't doit in the
+    // augmented logic since we need to _inject_ keys
     for para in paras {
         if let Some(override_wasm) = para.wasm_overrides() {
             let wasm_content = fs::read(override_wasm).await.unwrap_or_else(|_| {
@@ -308,7 +340,9 @@ pub async fn generate_default_overrides_for_para(
         // parachainSystem lastDmqMqcHead (emtpy)
         "45323df7cc47150b3930e2666b0aa313911a5dd3f1155f5b7d0c5aa102a757f9": "0000000000000000000000000000000000000000000000000000000000000000",
         // CollatorSelection DesiredCandidates (set to 1)
-        "15464cac3378d46f113cd5b7a4d71c84476f594316a7dfe49c1f352d95abdaf1": "01000000"
+        "15464cac3378d46f113cd5b7a4d71c84476f594316a7dfe49c1f352d95abdaf1": "01000000",
+        // Sudo Key (Alice)
+        "5c0d1176a568c1f92944340dbfed9e9c530ebca703c85910e7164cb7d1c9e47b": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
     });
 
     if let Some(override_wasm) = para.wasm_overrides() {
@@ -348,6 +382,30 @@ mod test {
     use super::*;
 
     #[test]
+    fn genesis_slot_encode_u64() {
+        let prefix = array_bytes::bytes2hex(
+            "",
+            substorager::storage_value_key(&b"Babe"[..], b"GenesisSlot"),
+        );
+        let mut a = 295769115_u64;
+        let a_encoded = a.encode();
+        println!("{}: {}", prefix, array_bytes::bytes2hex("", a_encoded));
+    }
+
+    #[test]
+    fn encode_u32() {
+        let a = 100_u32;
+        let a_encoded = a.encode();
+        println!("{}: {}", "a", array_bytes::bytes2hex("", a_encoded));
+    }
+
+    #[test]
+    fn validator_groups_count_hex() {
+        let validator_groups_count_hex = format!("{:02x}", 3 * 4);
+        println!("c: {validator_groups_count_hex}");
+    }
+
+    #[test]
     fn generate_paras_parachains_value_works() {
         let value = generate_paras_parachains_value([1000_u32]);
         println!("{value}");
@@ -361,6 +419,7 @@ mod test {
             "/tmp",
             &crate::config::Relaychain::new("polakdot"),
             &paras,
+            2,
         )
         .await;
     }
@@ -408,7 +467,9 @@ mod test {
         let validator_keys = get_validator_keys(2);
         let para = crate::config::Parachain::new("asset-hub");
         let paras = vec![&para];
-        let overrides = generate_rc_overrides(&validator_keys, &paras);
+        let mut overrides = generate_rc_overrides(&validator_keys);
+        let rc = Relaychain::new("polkadot");
+        augment_overrides_for_paras(&rc, &paras, &mut overrides);
 
         // Validator Validators
         assert_eq!(
@@ -483,6 +544,19 @@ mod test {
     }
 
     #[test]
+    fn encode_two_128() {
+        let name = array_bytes::bytes2hex("", subhasher::twox128(b":UsePreviousValidators:"));
+        println!(":UsePreviousValidators: : {name}");
+    }
+
+    #[test]
+    fn booleans() {
+        let t = true.encode();
+        let f = false.encode();
+        println!("true: {}", array_bytes::bytes2hex("", t));
+        println!("false: {}", array_bytes::bytes2hex("", f));
+    }
+    #[test]
     fn encode_hrmp() {
         let hrmp_prefix = array_bytes::bytes2hex(
             "",
@@ -502,6 +576,25 @@ mod test {
             "{prefix}{}",
             array_bytes::bytes2hex("", subhasher::twox256(0_u32.to_le_bytes()))
         );
-        println!("is: {core_0_descriptor_idx_key}");
+        println!("core: {core_0_descriptor_idx_key}");
+    }
+
+    #[test]
+    fn create_cores_desc() {
+        let para_id = ParaId(1000);
+        let para_hex = array_bytes::bytes2hex("", para_id.encode());
+        let prefix = array_bytes::bytes2hex(
+            "",
+            substorager::storage_value_key(&b"CoretimeAssignmentProvider"[..], b"CoreDescriptors"),
+        );
+        for core in 0..3 {
+            let core_descriptor_idx_key = format!(
+                "{prefix}{}",
+                array_bytes::bytes2hex("", subhasher::twox256((core as u32).to_le_bytes()))
+            );
+            let core_descriptor_value = format!("00010402{}00e100e100010000e1", para_hex);
+
+            println!("\"0x{core_descriptor_idx_key}: 0x{core_descriptor_value}\"");
+        }
     }
 }

--- a/src/overrides.rs
+++ b/src/overrides.rs
@@ -169,7 +169,7 @@ fn augment_overrides_for_paras(relay: &Relaychain, paras: &[&Parachain], overrid
     let mut core_index = 0_u32;
     let mut para_scheduler_value_parts: Vec<String> = vec![];
 
-    for  para in paras.iter() {
+    for para in paras.iter() {
         let para_id = ParaId(para.id());
 
         let para_twox64 = array_bytes::bytes2hex("", subhasher::twox64(para_id.encode()));

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -57,7 +57,7 @@ pub async fn sync_relay_only(
     let rc = Relaychain::new(chain.as_ref());
     env.push((
         "ZOMBIE_RC_EPOCH_DURATION".into(),
-        rc.epoch_duration().to_string().into(),
+        rc.epoch_duration().to_string(),
     ));
 
     // if we are sync westend, let doppelganger know to bypass
@@ -120,13 +120,13 @@ pub async fn sync_para(
     let sync_db_path = format!(
         "{}/paras/{}/sync-db",
         ns.base_dir().to_string_lossy(),
-        &chain,
+        chain,
     );
 
     let para_head_path = format!(
         "{}/paras/{}/head.txt",
         ns.base_dir().to_string_lossy(),
-        &chain,
+        chain,
     );
 
     let rpc_random_port = get_random_port().await;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -51,8 +51,19 @@ pub async fn sync_relay_only(
     env.push(("ZOMBIE_RC_OVERRIDES_PATH".to_string(), rc_overrides_path));
     env.push(("RUST_LOG".into(), "doppelganger=debug".into()));
     env.push(("ZOMBIE_INFO_PATH".into(), info_path.as_ref().into()));
-    if chain.as_ref() == "paseo" || chain.as_ref() == "kusama" {
-        env.push(("ZOMBIE_RC_EPOCH_DURATION".into(), "600".into()));
+    env.push(("ZOMBIE_CHAIN".into(), chain.as_ref().into()));
+
+    // get the epoch duration from the chain config
+    let rc = Relaychain::new(chain.as_ref());
+    env.push((
+        "ZOMBIE_RC_EPOCH_DURATION".into(),
+        rc.epoch_duration().to_string().into(),
+    ));
+
+    // if we are sync westend, let doppelganger know to bypass
+    // justification checks
+    if chain.as_ref() == "westend" {
+        env.push(("ZOMBIE_IS_WESTEND".into(), "1".into()));
     }
 
     trace!("env: {env:?}");
@@ -150,6 +161,8 @@ pub async fn sync_para(
         let mut content = Cursor::new(response.bytes().await.expect("Create cursor should works."));
         std::io::copy(&mut content, &mut file).expect("Copy bytes should works.");
         dest_for_paseo.as_str()
+    } else if let Some(chain_spec) = parachain.chain_spec() {
+        chain_spec
     } else {
         chain.as_ref()
     };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -369,7 +369,7 @@ pub async fn localize_config(config_path: impl AsRef<str>) -> Result<(), anyhow:
         // rename original
         fs::rename(
             &config_path,
-            &format!("{}/original-config.toml", &base_path.to_string_lossy()),
+            &format!("{}/original-config.toml", base_path.to_string_lossy()),
         )
         .await
         .expect("rename should works");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -463,7 +463,7 @@ mod test {
 
     #[test]
     fn encode_u32() {
-        let val = 2_u32;
+        let val = 56_u32;
         let encoded = val.encode();
         println!("{}", array_bytes::bytes2hex("0x", encoded));
     }


### PR DESCRIPTION
- Add support for westend
- Set `UsePreviousValidators` to _true_ as part of the override process.
- Add req_cores per parachain logic. (hardcoded in config for system chains)