### PR TITLE
bump version `v0.3.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10780,7 +10780,7 @@ dependencies = [
 
 [[package]]
 name = "zombie-bite"
-version = "0.2.26"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "array-bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zombie-bite"
-version = "0.2.26"
+version = "0.3.0"
 edition = "2021"
 default-run = "zombie-bite"
 


### PR DESCRIPTION
This version require doppelganger > `v0.2.0`.
- Add westend support 